### PR TITLE
Fix notification response.id check

### DIFF
--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -63,7 +63,7 @@ export default function createStreamMiddleware() {
   ) {
     let err;
     try {
-      const isNotification = !res.id;
+      const isNotification = !('id' in res);
       if (isNotification) {
         processNotification((res as unknown) as JsonRpcNotification<unknown>);
       } else {


### PR DESCRIPTION
A JSON-RPC notification is defined as a JSON-RPC request whose `id` field is _missing_. [Specifically](https://www.jsonrpc.org/specification#notification):

> A Notification is a Request object without an "id" member. 

The number `0` is a valid ID, but this package will currently erroneously identify requests with `id: 0` as notifications. We should fix this.

_Note:_ Should not be merged until `id` validation is added to `json-rpc-engine`.