### PR TITLE
Don't throw in StreamMiddleware if id doesn't exist

### DIFF
--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -79,7 +79,8 @@ export default function createStreamMiddleware() {
   function processResponse(res: PendingJsonRpcResponse<unknown>) {
     const context = idMap[(res.id as unknown) as string];
     if (!context) {
-      throw new Error(`StreamMiddleware - Unknown response id "${res.id}"`);
+      console.warn(`StreamMiddleware - Unknown response id "${res.id}"`);
+      return;
     }
 
     delete idMap[(res.id as unknown) as string];


### PR DESCRIPTION
Throwing an error causes the stream to break, which is generally undesirable