### PR TITLE
fix: clean up engine listener

### DIFF
--- a/src/createEngineStream.ts
+++ b/src/createEngineStream.ts
@@ -21,9 +21,9 @@ export default function createEngineStream(opts: EngineStreamOptions): Duplex {
   const stream = new Duplex({ objectMode: true, read, write });
   // forward notifications
   if (engine.on) {
-    engine.on('notification', (message) => {
-      stream.push(message);
-    });
+    const onNotification = (message: unknown) => stream.push(message);
+    engine.on('notification', onNotification);
+    stream.on('close', () => engine.off('notification', onNotification));
   }
   return stream;
 


### PR DESCRIPTION
`engine` may be a long-lived object. Failing to clean up the `notification` listener results in a memory leak in the event that many ephemeral streams are created with the same `engine` -- for example, extension popups or browser tabs. This fixes the issue.