### PR TITLE
Request retry count

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 78.94,
+      branches: 85.71,
       functions: 100,
-      lines: 96.27,
-      statements: 96.27,
+      lines: 97.44,
+      statements: 97.44,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 86.36,
+      branches: 86.95,
       functions: 100,
-      lines: 97.48,
-      statements: 97.48,
+      lines: 97.51,
+      statements: 97.51,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 85.71,
+      branches: 86.36,
       functions: 100,
-      lines: 97.44,
-      statements: 97.44,
+      lines: 97.48,
+      statements: 97.48,
     },
   },
 

--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -136,11 +136,13 @@ export default function createStreamMiddleware(options: Options = {}) {
       if (!req.id) {
         return;
       }
+
       if (retryCount >= 3) {
         throw new Error(
           `StreamMiddleware - Retry limit exceeded for request id "${req.id}"`,
         );
       }
+
       idMap[req.id].retryCount = retryCount + 1;
       sendToStream(req);
     });

--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -103,7 +103,12 @@ export default function createStreamMiddleware(options: Options = {}) {
   function processResponse(res: PendingJsonRpcResponse<unknown>) {
     const context = idMap[res.id as unknown as string];
     if (!context) {
-      throw new Error(`StreamMiddleware - Unknown response id "${res.id}"`);
+      // In case response is received and corresponsing request is not present in idMap
+      // we only show warning and not throw error anymore.
+      // Reason for change is that due to MV3 we have added action replay capability
+      // Thus it can happen that a request ends up being submitted upto 3 retries and there are multiple responses
+      console.warn(`StreamMiddleware - Unknown response id "${res.id}"`);
+      return;
     }
 
     delete idMap[res.id as unknown as string];

--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -133,7 +133,10 @@ export default function createStreamMiddleware(options: Options = {}) {
     Object.values(idMap).forEach(({ req, retryCount = 0 }) => {
       // Avoid retrying requests without an id - they cannot have matching responses so retry logic doesn't apply
       // Check for retry count below ensure that a request is not retried more than 3 times
-      if (!req.id || retryCount >= 3) {
+      if (!req.id) {
+        return;
+      }
+      if (retryCount >= 3) {
         throw new Error(
           `StreamMiddleware - Retry limit exceeded for request id "${req.id}"`,
         );

--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -103,12 +103,7 @@ export default function createStreamMiddleware(options: Options = {}) {
   function processResponse(res: PendingJsonRpcResponse<unknown>) {
     const context = idMap[res.id as unknown as string];
     if (!context) {
-      // In case response is received and corresponsing request is not present in idMap
-      // we only show warning and not throw error anymore.
-      // Reason for change is that due to MV3 we have added action replay capability
-      // Thus it can happen that a request ends up being submitted upto 3 retries and there are multiple responses
-      console.warn(`StreamMiddleware - Unknown response id "${res.id}"`);
-      return;
+      throw new Error(`StreamMiddleware - Unknown response id "${res.id}"`);
     }
 
     delete idMap[res.id as unknown as string];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -220,6 +220,6 @@ describe('retry logic in middleware connected to a port', () => {
       messageConsumer({
         method: RECONNECTED,
       });
-    }).toThrow();
+    }).toThrowError();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -220,6 +220,6 @@ describe('retry logic in middleware connected to a port', () => {
       messageConsumer({
         method: RECONNECTED,
       });
-    }).toThrow();
+    }).toThrow('StreamMiddleware - Retry limit exceeded for request id');
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -109,8 +109,7 @@ describe('middleware and engine to stream', () => {
 
 const RECONNECTED = 'CONNECTED';
 describe('retry logic in middleware connected to a port', () => {
-  let engineA: JsonRpcEngine | undefined = undefined;
-  let engineB;
+  let engineA: JsonRpcEngine | undefined;
   let messages: any[] = [];
   let messageConsumer: any;
   beforeEach(() => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -220,6 +220,6 @@ describe('retry logic in middleware connected to a port', () => {
       messageConsumer({
         method: RECONNECTED,
       });
-    }).toThrowError();
+    }).toThrow();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -185,7 +185,7 @@ describe('retry logic in middleware connected to a port', () => {
     expect(messages).toHaveLength(5);
   });
 
-  it('requests are not retried more than 3 times', async () => {
+  it('throw error when requests are retried more than 3 times', async () => {
     // request and expected result
     const req = { id: 1, jsonrpc, method: 'test' };
 
@@ -216,10 +216,10 @@ describe('retry logic in middleware connected to a port', () => {
     expect(messages).toHaveLength(4);
 
     // Reconnected, request is not sent again gets sent again message count stays at 4
-    messageConsumer({
-      method: RECONNECTED,
-    });
-    await artificialDelay();
-    expect(messages).toHaveLength(4);
+    expect(() => {
+      messageConsumer({
+        method: RECONNECTED,
+      });
+    }).toThrow();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -215,11 +215,28 @@ describe('retry logic in middleware connected to a port', () => {
     await artificialDelay();
     expect(messages).toHaveLength(4);
 
-    // Reconnected, request is not sent again gets sent again message count stays at 4
+    // Reconnected, error is thrrown when trying to resend request more that 3 times
     expect(() => {
       messageConsumer({
         method: RECONNECTED,
       });
     }).toThrow('StreamMiddleware - Retry limit exceeded for request id');
+  });
+
+  it('does not retry if the request has no id', async () => {
+    // request and expected result
+    const req = { id: undefined, jsonrpc, method: 'test' };
+
+    // Initially sent once, message count at 1
+    engineA?.handle(req);
+    await artificialDelay();
+    expect(messages).toHaveLength(1);
+
+    // Reconnected, but request is not re-submitted
+    messageConsumer({
+      method: RECONNECTED,
+    });
+    await artificialDelay();
+    expect(messages).toHaveLength(1);
   });
 });


### PR DESCRIPTION
The PR has following changes, in context of DAPP action replay for MV3:

1. add retry count to request, max retries are 3
2. requests are not retried if `request.id` is `undefined`, `undefined` is valid value of `request.id`.
3. error is not throw is a response is encountered for which there is no corresponding request - reason for doing this change is at times I found that due to service worker restart requests are sent to background multiple times and there are multiple responses, as first response matched request is removed from queue and then as second response reaches there is no corresponding request and it throws exception