### PR TITLE
Remove error throw when response is seen for unknown request

### DIFF
--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -103,7 +103,7 @@ export default function createStreamMiddleware(options: Options = {}) {
   function processResponse(res: PendingJsonRpcResponse<unknown>) {
     const context = idMap[res.id as unknown as string];
     if (!context) {
-      throw new Error(`StreamMiddleware - Unknown response id "${res.id}"`);
+      console.warn(`StreamMiddleware - Unknown response id "${res.id}"`);
     }
 
     delete idMap[res.id as unknown as string];


### PR DESCRIPTION
Remove error thrown when response is seen for id which does not have corresponding request.

@Gudahtt : we had discussion about this on the last PR, but as I was playing around with DAPP action replay feature I could replicate this error. Reason I found is - as service worker restart we wait for state in background to be ready to send message to provider to replay actions (there are couple of asynchronous events to be executed for background state to be initialised). While this is being done provider may send send requests already which will also be replayed.

Thus we need to ignore duplicate responses which are possible after replay feature.