### PR TITLE
Add early return if JSON RPC request is not found

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,8 +23,8 @@ module.exports = {
     global: {
       branches: 86.95,
       functions: 100,
-      lines: 97.51,
-      statements: 97.51,
+      lines: 97.02,
+      statements: 97.02,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 86.95,
+      branches: 91.3,
       functions: 100,
-      lines: 97.02,
-      statements: 97.02,
+      lines: 98.51,
+      statements: 98.51,
     },
   },
 

--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -104,6 +104,7 @@ export default function createStreamMiddleware(options: Options = {}) {
     const context = idMap[res.id as unknown as string];
     if (!context) {
       console.warn(`StreamMiddleware - Unknown response id "${res.id}"`);
+      return;
     }
 
     delete idMap[res.id as unknown as string];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -224,8 +224,6 @@ describe('retry logic in middleware connected to a port', () => {
   });
 
   it('does not throw error when response is received for request not in map', async () => {
-    // request and expected result
-    const req = { id: 1, jsonrpc, method: 'test' };
     const res = { id: 1, jsonrpc, result: 'test' };
 
     messageConsumer(res);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -223,6 +223,19 @@ describe('retry logic in middleware connected to a port', () => {
     }).toThrow('StreamMiddleware - Retry limit exceeded for request id');
   });
 
+  it('does not throw error when response is received for request not in map', async () => {
+    // request and expected result
+    const req = { id: 1, jsonrpc, method: 'test' };
+    const res = { id: 1, jsonrpc, result: 'test' };
+
+    messageConsumer(res);
+
+    expect(() => {
+      messageConsumer(res);
+      messageConsumer(res);
+    }).not.toThrow();
+  });
+
   it('does not retry if the request has no id', async () => {
     // request and expected result
     const req = { id: undefined, jsonrpc, method: 'test' };


### PR DESCRIPTION
Return statement was missed by me in previous PR, I found that by testing in latest code.