### PR TITLE
fix: race issue in stream processing

### DIFF
--- a/src/createStreamMiddleware.ts
+++ b/src/createStreamMiddleware.ts
@@ -50,10 +50,10 @@ export default function createStreamMiddleware(options: Options = {}) {
     next,
     end,
   ) => {
+    // register request on id map *before* sending it to the stream, to avoid race issues
+    idMap[req.id as unknown as string] = { req, res, next, end };
     // write req to stream
     sendToStream(req);
-    // register request on id map
-    idMap[req.id as unknown as string] = { req, res, next, end };
   };
 
   return { events, middleware, stream };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,13 +18,17 @@ describe('createStreamMiddleware', () => {
     const initRes = { id: 1, jsonrpc };
     const res = { id: 1, jsonrpc, result: 'test' };
 
-    await new Promise<void>((resolve, reject) => {
-      // listen for incoming requests
-      jsonRpcConnection.stream.on('data', (_req) => {
-        expect(req).toStrictEqual(_req);
-        jsonRpcConnection.stream.write(res);
-      });
+    // listen for incoming requests
+    jsonRpcConnection.stream.on('data', (_req) => {
+      expect(req).toStrictEqual(_req);
+      jsonRpcConnection.stream.write(res);
+    });
 
+    // wait for the stream to be ready
+    await artificialDelay();
+
+    // eslint-disable-next-line no-async-promise-executor
+    await new Promise<void>((resolve, reject) => {
       // run middleware, expect end fn to be called
       jsonRpcConnection.middleware(
         req,


### PR DESCRIPTION
Fixes https://github.com/Uniswap/interface/issues/6613 by resolving a race condition with `ReadableStream` pipes: initialized pipes may process data synchronously, but uninitialized pipes will process data asynchronously (only after being initialized):

- Adds a test exposing the race condition
- Reorders setting state and sending to stream to avoid the race condition