### PR TITLE
fix: move json-rpc-engine from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@metamask/safe-event-emitter": "^3.0.0",
+    "json-rpc-engine": "^6.1.0",
     "readable-stream": "^2.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
`json-rpc-engine` is actually a runtime dependency but was not declared as such.


https://github.com/MetaMask/json-rpc-middleware-stream/blob/main/src/createEngineStream.ts#L2

This fixes that.

#### Blocking
- #58 
  - #54 
  - #55 