### PR TITLE
upgrade typescript version to 4.6.3 to be inline with core monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
-    "typescript": "^4.2.4",
+    "typescript": "~4.6.3",
     "webextension-polyfill-ts": "^0.26.0"
   },
   "packageManager": "yarn@3.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4422,7 +4422,7 @@ __metadata:
     rimraf: ^3.0.2
     ts-jest: ^27.1.4
     ts-node: ^10.7.0
-    typescript: ^4.2.4
+    typescript: ~4.6.3
     webextension-polyfill-ts: ^0.26.0
   languageName: unknown
   linkType: soft
@@ -6119,23 +6119,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.2.4":
-  version: 4.7.4
-  resolution: "typescript@npm:4.7.4"
+"typescript@npm:~4.6.3":
+  version: 4.6.4
+  resolution: "typescript@npm:4.6.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
+  checksum: e7bfcc39cd4571a63a54e5ea21f16b8445268b9900bf55aee0e02ad981be576acc140eba24f1af5e3c1457767c96cea6d12861768fb386cf3ffb34013718631a
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.2.4#~builtin<compat/typescript>":
-  version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=65a307"
+"typescript@patch:typescript@~4.6.3#~builtin<compat/typescript>":
+  version: 4.6.4
+  resolution: "typescript@patch:typescript@npm%3A4.6.4#~builtin<compat/typescript>::version=4.6.4&hash=5d3a66"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
+  checksum: 1cb434fbc637d347be90e3a0c6cd05e33c38f941713c8786d3031faf1842c2c148ba91d2fac01e7276b0ae3249b8633f1660e32686cc7a8c6a8fd5361dc52c66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We would like to migrate this repo to the core monorepo. Before the actual migration, we would like to make sure yarn version and typescript version are inline with the core monorepo. 

In this pull request we are upgrading the typescript version to 4.6.3.

* Fixes <[url-issue](https://app.zenhub.com/workspaces/shared-libraries-621e46b4d7103800171d1b02/issues/gh/metamask/core/1679)>