### PR TITLE
Deter people from making new changes to this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # json-rpc-middleware-stream
 
+<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/core"><code>core</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over.</p></td></tr></table>
+
 A small toolset for streaming JSON RPC data and matching requests and responses. Made to be used with [`@metamask/json-rpc-engine`](https://npmjs.com/package/@metamask/json-rpc-engine).


### PR DESCRIPTION
We are working on migrating this repo to our `core` monorepo. New changes to this repo will not be carried over (and will likely need to be reverted).